### PR TITLE
Run specs in GH Action

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  DATABASE_URL_TEST: postgresql://postgres:postgres@localhost/eras_test
+  DATABASE_URL_TEST: postgresql://eras:eras@localhost/eras_test
   RAILS_ENV: test
 
 jobs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,46 @@
+name: Run Rspec
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  DATABASE_URL_TEST: postgresql://postgres:postgres@localhost/eras_test
+  RAILS_ENV: test
+
+jobs:
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: timescale/timescaledb:2.11.0-pg15
+        env:
+          POSTGRES_PASSWORD: eras
+          POSTGRES_USER: eras
+        ports:
+        - 5432:5432
+        options:
+          --health-cmd pg_isready
+          --health-interval 10ms
+          --health-timeout 500ms
+          --health-retries 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.5.2
+
+      - name: Check for focused specs
+        run: ./scripts/no_focus.sh
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
+          bundler-cache: true
+
+      - name: Setup test database
+        run: bin/rails db:create
+
+      - name: Run tests
+        run: bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.0-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.0-x86_64-linux)
+      racc (~> 1.4)
     pg (1.4.6)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -177,7 +179,9 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,6 +10,7 @@ development:
 
 test:
   <<: *default
+  url: <%= ENV.fetch('DATABASE_URL_TEST', 'postgresql://eras:eras@localhost/eras_test') %>
 
 production:
   <<: *default

--- a/scripts/no_focus.sh
+++ b/scripts/no_focus.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+! grep -R "\(describe\|context\|it\).*\(:focus\|focus:\)" spec/


### PR DESCRIPTION
There's a shared action for this, but it will need to be updated to allow me to specify the postgres image to use. In the mean time, this can be used to ensure specs are running for PR reviews.

(fyi: the "no_focus.sh" script is a failsafe we've always used to make sure that the `:focus` keyword used to run a single spec of block of specs at a time isn't left in.)