### PR TITLE
Use correct main branch for staging deploy

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -3,7 +3,7 @@ name: Deploy to Staging
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Repo's trunk is called `main`, not `master`. Fixes deploy trigger to use `main`.