### PR TITLE
Deploy lambda forwarder via GHA

### DIFF
--- a/.github/workflows/deploy_lambda_staging.yml
+++ b/.github/workflows/deploy_lambda_staging.yml
@@ -1,0 +1,40 @@
+name: Deploy Lambda Function
+
+on:
+  push:
+    tags:
+      - lambda-release
+  workflow_dispatch:
+
+jobs:
+  deploy_lambda:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./kinesis-to-http
+    name: Deploy lambda function
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.LAMBDA_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.LAMBDA_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-session-name: lambda-deploy-staging
+
+      - name: Install dependencies
+        run: |
+          mkdir ./package && pip install --target ./package requests
+
+      - name: Zip package
+        run: |
+          zip -r ./lambda.zip .
+
+      - name: AWS Deploy
+        run: |
+          aws lambda update-function-code \
+            --function-name eras-forwarder-staging \
+            --zip-file fileb://lambda.zip

--- a/kinesis-to-http/kinesis-forwarder-staging.py
+++ b/kinesis-to-http/kinesis-forwarder-staging.py
@@ -1,0 +1,15 @@
+import json
+import base64
+import requests
+
+HEADERS  = {"Content-Type": "application/json", "Accept": "application/json"}
+ENDPOINT = "https://eras-staging.zooniverse.org/kinesis"
+
+def lambda_handler(event, context):
+    payloads = [json.loads(base64.b64decode(record["kinesis"]["data"])) for record in event["Records"]]
+    dicts    = [payload for payload in payloads]
+
+    if dicts:
+        data = json.dumps({"payload": dicts})
+        r = requests.post(ENDPOINT, headers=HEADERS, data=data)
+        r.raise_for_status()


### PR DESCRIPTION
Includes:
* the lambda forwarder, which will POST all events to forwards on all events to the `/kinesis` route, one per env.
* deploy template that uses creds from a IAM user `lambda-forwarder` that has full `lambda:*` access, potentially for use with other repos later. Builds the deps (just requests and its own, but worth it) and pushes a zipped update via the AWS CLI.

Action is untested because of how GH has to see an action on main before it'll let you run it, so this might need a little fiddling. To confirm it works, we'll see the upload succeed in the AWS console and should be able to throw test payloads at the function and see a result in the Eras logs. 

Next step is to hook the staging kinesis stream up to a trigger on the lambda (all in the console), which will start throwing data at Eras.