### PR TITLE
revert session time back to float

### DIFF
--- a/db/migrate/20230605192518_change_session_time_to_be_decimal.rb
+++ b/db/migrate/20230605192518_change_session_time_to_be_decimal.rb
@@ -1,6 +1,0 @@
-class ChangeSessionTimeToBeDecimal < ActiveRecord::Migration[7.0]
-  def change
-    change_column :classification_events, :session_time, :decimal, :precision => 15, :scale => 10
-    change_column :classification_user_groups, :session_time, :decimal, :precision => 15, :scale => 10
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,7 +25,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_223200) do
     t.bigint "workflow_id"
     t.bigint "user_id"
     t.bigint "user_group_ids", default: [], array: true
-    t.decimal "session_time", precision: 15, scale: 10
+    t.float "session_time"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["event_time"], name: "classification_events_event_time_idx", order: :desc
@@ -35,7 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_223200) do
     t.bigint "classification_id"
     t.datetime "event_time", precision: nil, null: false
     t.bigint "user_group_id"
-    t.decimal "session_time", precision: 15, scale: 10
+    t.float "session_time"
     t.bigint "project_id"
     t.bigint "user_id"
     t.bigint "workflow_id"


### PR DESCRIPTION
originally turned to decimal for precision, but decimals and precision are more trouble than its worth. and precision by seconds mean little in the grand scheme of our use case