### PR TITLE
update error message on /classifications/users when querying for all project contributions [ordered by desc count]. (no longer top projects)

### DIFF
--- a/app/controllers/user_classification_count_controller.rb
+++ b/app/controllers/user_classification_count_controller.rb
@@ -16,7 +16,7 @@ class UserClassificationCountController < ApplicationController
 
   def validate_params
     super
-    raise ValidationError, 'Cannot query top projects and query by project/workflow' if params[:project_contributions] && (params[:workflow_id] || params[:project_id])
+    raise ValidationError, 'Cannot query for project contributions and query by project/workflow' if params[:project_contributions] && (params[:workflow_id] || params[:project_id])
   end
 
   def sanitize_params

--- a/spec/controllers/user_classification_count_controller_spec.rb
+++ b/spec/controllers/user_classification_count_controller_spec.rb
@@ -99,13 +99,13 @@ RSpec.describe UserClassificationCountController do
       it 'ensures you cannot query by workflow and project_contributions' do
         get :query, params:  { id: 1, project_contributions: true, workflow_id: 1 }
         expect(response.status).to eq(400)
-        expect(response.body).to include('Cannot query top projects and query by project/workflow')
+        expect(response.body).to include('Cannot query for project contributions and query by project/workflow')
       end
 
       it 'ensures you cannot query by project and top project contributions' do
         get :query, params: { id: 1, project_contributions: true, project_id: 1 }
         expect(response.status).to eq(400)
-        expect(response.body).to include('Cannot query top projects and query by project/workflow')
+        expect(response.body).to include('Cannot query for project contributions and query by project/workflow')
       end
 
       it 'ensures project_contributions is an boolean' do


### PR DESCRIPTION
update error message when querying for all project_conributions and project_id/workflow_id

Per Design: https://www.figma.com/file/qbqbmR3t5XV6eKcpuRj7mG/Group-Stats?type=design&node-id=0-1&mode=design
We updated our responses from grabbing a limited number of top projects (i.e. param of `top_project_contributions=N` to a boolean on whether or not response should show all project contributions (ordered by classification count per project))