### PR TITLE
update user_classification_counts_serializer so that response will not display session_time if time_spent param is false

### DIFF
--- a/app/serializers/user_classification_counts_serializer.rb
+++ b/app/serializers/user_classification_counts_serializer.rb
@@ -33,8 +33,8 @@ class UserClassificationCountsSerializer
     if show_project_contributions
       counts_grouped_by_period = user_counts.group_by { |user_proj_class_count| user_proj_class_count[:period] }.transform_values do |counts_in_period|
         total_in_period = { count: counts_in_period.sum(&:count) }
-        total_in_period[:session_time] = counts_in_period.sum(&:session_time) if show_time_spent
-        total_in_period
+        total_in_period_session_time = { session_time: counts_in_period.sum(&:session_time) } if show_time_spent
+        show_time_spent ? total_in_period.merge(total_in_period_session_time) : total_in_period
       end
       counts_grouped_by_period.map { |period, totals| { period: }.merge(totals) }
     else


### PR DESCRIPTION
update user classification counts so that if show_time_spent is false when filtering user classification counts by project, session_time is not returned as a key