### PR TITLE
Update user classification counts filtering by project if session time is false. do not return session time as key in response

### DIFF
--- a/app/serializers/user_classification_counts_serializer.rb
+++ b/app/serializers/user_classification_counts_serializer.rb
@@ -33,8 +33,8 @@ class UserClassificationCountsSerializer
     if show_project_contributions
       counts_grouped_by_period = user_counts.group_by { |user_proj_class_count| user_proj_class_count[:period] }.transform_values do |counts_in_period|
         total_in_period = { count: counts_in_period.sum(&:count) }
-        total_in_period[:session_time] = counts_in_period.sum(&:session_time) if show_time_spent
-        total_in_period
+        total_in_period_session_time = { session_time: counts_in_period.sum(&:session_time) } if show_time_spent
+        show_time_spent ? total_in_period.merge(total_in_period_session_time) : total_in_period
       end
       counts_grouped_by_period.map { |period, totals| { period: }.merge(totals) }
     else

--- a/app/serializers/user_classification_counts_serializer.rb
+++ b/app/serializers/user_classification_counts_serializer.rb
@@ -38,7 +38,13 @@ class UserClassificationCountsSerializer
       end
       counts_grouped_by_period.map { |period, totals| { period: }.merge(totals) }
     else
-      user_counts
+      user_counts.map do |c|
+        period_data = {
+          period: c.period,
+          count: c.count
+        }
+        show_time_spent ? period_data.merge({ session_time: c.session_time }) : period_data
+      end
     end
   end
 

--- a/spec/controllers/user_classification_count_controller_spec.rb
+++ b/spec/controllers/user_classification_count_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe UserClassificationCountController do
         expect(response_body['data'][0]['count']).to eq(1)
       end
 
-      it 'returns total_count and time_spent and breakdown of user classifications wher period is given' do
+      it 'returns total_count and time_spent and breakdown of user classifications where period is given' do
         get :query, params: { id: classification_event.user_id, period: 'day', time_spent: true }
         expect(response.status).to eq(200)
         response_body = JSON.parse(response.body)
@@ -46,6 +46,13 @@ RSpec.describe UserClassificationCountController do
         response_body = JSON.parse(response.body)
         expect(response_body['project_contributions'].length).to eq(1)
         expect(response_body['project_contributions'][0]['project_id']).to eq(classification_event.project_id)
+      end
+
+      it 'returns user project classification counts without session_time if time_spent is false' do
+        get :query, params: { id: classification_event.user_id, project_id: 1, period: 'day' }
+        expect(response.status).to eq(200)
+        response_body = JSON.parse(response.body)
+        expect(response_body['data'][0]).not_to have_key('session_time')
       end
     end
 


### PR DESCRIPTION
Small bug found: 
eg. 
`https://eras-staging.zooniverse.org/classifications/users/1234?start_date=2022-03-10&project_id=1974&period=day`

returns
```
{
    "total_count": 24,
    "data": [
        {
            "period": "2022-09-09T00:00:00.000Z",
            "count": 23,
            "session_time": null
        },
        {
            "period": "2022-09-20T00:00:00.000Z",
            "count": 1,
            "session_time": null
        }
    ]
}
```

This PR makes sure session_time is not a key in response data when time_spent=true