### PR TITLE
Update backfill scripts for classifications

### DIFF
--- a/scripts/backfill_classifications.py
+++ b/scripts/backfill_classifications.py
@@ -14,16 +14,18 @@ ERAS_USER = os.getenv('ERAS_USER')
 ERAS_PW = os.getenv('ERAS_PW')
 FIRST_INGESTED_CLASSIFICATION_ID = os.getenv('FIRST_INGESTED_CLASSIFICATION_ID')
 
-now = datetime.now()
-current_time = now.strftime("%H:%M:%S")
-print("CLASSIFICATIONS backfill BEFORE Time =", current_time)
+start_time = datetime.now()
+print("CLASSIFICATIONS backfill BEFORE Time =", start_time)
+
+classifications_query = "select id::bigint as classification_id, created_at as event_time, updated_at as classification_updated_at, CASE WHEN metadata ->> 'started_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'started_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'started_at', 'YYYY-MM-DD HH24:MI:SS') END started_at,  CASE WHEN metadata ->> 'finished_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'finished_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'finished_at', 'YYYY-MM-DD HH24:MI:SS') END finished_at, project_id::bigint, workflow_id::bigint, user_id::bigint, array_remove(string_to_array(replace(replace(replace(metadata ->> 'user_group_ids', '[', ''), ']', ''), ' ', '' ), ','), 'null')::bigint[] as user_group_ids, EXTRACT(EPOCH FROM (CASE WHEN metadata ->> 'finished_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'finished_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'finished_at', 'YYYY-MM-DD HH24:MI:SS') END) - (CASE WHEN metadata ->> 'started_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'started_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'started_at', 'YYYY-MM-DD HH24:MI:SS') END)) as session_time, created_at, updated_at from classifications where id < %s order by id desc limit 5000000"
+
 
 with psycopg.connect(f"host={PANOPTES_CONN} port={PANOPTES_PORT} dbname={PANOPTES_DB} user={PANOPTES_USER} password={PANOPTES_PW} sslmode=require") as panoptes_db_conn, psycopg.connect(f"host={TIMESCALE_CONNECTION} port={TIMESCALE_PORT} dbname={ERAS_DB} user={ERAS_USER} password={ERAS_PW} sslmode=require") as timescale_db_conn:
-    with panoptes_db_conn.cursor(name="panoptes_cursor").copy("COPY (select id::bigint as classification_id, created_at as event_time, updated_at as classification_updated_at, CASE WHEN metadata ->> 'started_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'started_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'started_at', 'YYYY-MM-DD HH24:MI:SS') END started_at,  CASE WHEN metadata ->> 'finished_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'finished_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'finished_at', 'YYYY-MM-DD HH24:MI:SS') END finished_at, project_id::bigint, workflow_id::bigint, user_id::bigint, string_to_array(replace(replace(replace(metadata ->> 'user_group_ids', '[', ''), ']', ''), ' ', '' ), ',')::bigint[] as user_group_ids, EXTRACT(EPOCH FROM (CASE WHEN metadata ->> 'finished_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'finished_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'finished_at', 'YYYY-MM-DD HH24:MI:SS') END) - (CASE WHEN metadata ->> 'started_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'started_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'started_at', 'YYYY-MM-DD HH24:MI:SS') END)) as session_time, created_at, updated_at from classifications where id < %s order by id) TO STDOUT (FORMAT BINARY)", (FIRST_INGESTED_CLASSIFICATION_ID,)) as panoptes_copy:
-        with timescale_db_conn.cursor().copy("COPY classification_events FROM STDIN (FORMAT BINARY)") as timescale_copy:
+    with panoptes_db_conn.cursor(name="panoptes_cursor").copy(f"COPY ({classifications_query}) TO STDOUT (FORMAT BINARY)", (FIRST_INGESTED_CLASSIFICATION_ID,)) as panoptes_copy:
+        with timescale_db_conn.cursor(name="timescale_cursor").copy("COPY classification_events FROM STDIN (FORMAT BINARY)") as timescale_copy:
             for data in panoptes_copy:
                 timescale_copy.write(data)
 
-            finish = datetime.now()
-            finish_time = finish.strftime("%H:%M:%S")
-            print("CLASSIFICATIONS backfill AFTER Time =", finish_time)
+
+finish_time = datetime.now()
+print("CLASSIFICATIONS backfill AFTER Time =", finish_time)

--- a/scripts/backfill_classifications_chunk_in_files.py
+++ b/scripts/backfill_classifications_chunk_in_files.py
@@ -1,0 +1,57 @@
+import os
+import psycopg
+from datetime import datetime
+import math
+
+PANOPTES_CONN = os.getenv('PANOPTES_CONN')
+PANOPTES_PORT = os.getenv('PANOPTES_PORT')
+PANOPTES_DB = os.getenv('PANOPTES_DB')
+PANOPTES_USER = os.getenv('PANOPTES_USER')
+PANOPTES_PW = os.getenv('PANOPTES_PW')
+TIMESCALE_CONNECTION = os.getenv('TIMESCALE_CONNECTION')
+TIMESCALE_PORT = os.getenv('TIMESCALE_PORT')
+ERAS_DB = os.getenv('ERAS_DB')
+ERAS_USER = os.getenv('ERAS_USER')
+ERAS_PW = os.getenv('ERAS_PW')
+FIRST_INGESTED_CLASSIFICATION_ID = os.getenv('FIRST_INGESTED_CLASSIFICATION_ID')
+
+start_time = datetime.now()
+print("CLASSIFICATIONS backfill BEFORE Time =", start_time)
+
+offset = 0
+limit = 10000000
+
+classifications_query = "select id::bigint as classification_id, created_at as event_time, updated_at as classification_updated_at, CASE WHEN metadata ->> 'started_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'started_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'started_at', 'YYYY-MM-DD HH24:MI:SS') END started_at,  CASE WHEN metadata ->> 'finished_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'finished_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'finished_at', 'YYYY-MM-DD HH24:MI:SS') END finished_at, project_id::bigint, workflow_id::bigint, user_id::bigint, array_remove(string_to_array(replace(replace(replace(metadata ->> 'user_group_ids', '[', ''), ']', ''), ' ', '' ), ','), 'null')::bigint[] as user_group_ids, EXTRACT(EPOCH FROM (CASE WHEN metadata ->> 'finished_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'finished_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'finished_at', 'YYYY-MM-DD HH24:MI:SS') END) - (CASE WHEN metadata ->> 'started_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'started_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'started_at', 'YYYY-MM-DD HH24:MI:SS') END)) as session_time, created_at, updated_at from classifications where id < %s order by id desc limit %s"
+
+num_files = math.ceil(FIRST_INGESTED_CLASSIFICATION_ID/limit)
+
+while offset <= num_files:
+  query = ''
+
+  if offset == 0:
+    query = f"{classifications_query} limit {limit}"
+  else:
+    query = f"{classifications_query} limit {limit} offset {limit * offset}"
+
+  with psycopg.connect(f"host={PANOPTES_CONN} port={PANOPTES_PORT} dbname={PANOPTES_DB} user={PANOPTES_USER} password={PANOPTES_PW} sslmode=require") as panoptes_db_conn:
+    with open(f"prod_classifications_{offset}.csv", "wb") as f:
+        with panoptes_db_conn.cursor(name="panoptes_cursor").copy(f"COPY ({classifications_query}) TO STDOUT WITH CSV HEADER", (FIRST_INGESTED_CLASSIFICATION_ID, limit)) as panoptes_copy:
+            for data in panoptes_copy:
+                f.write(data)
+    offset+= 1
+
+finish_copy_time = datetime.now()
+print("PANOPTES Classification Copy over at ", finish_copy_time)
+print("TIMESCALE START COPY FROM CSV")
+
+output_file_no = 0
+while output_file_no < num_files:
+    with psycopg.connect(f"host={TIMESCALE_CONNECTION} port={TIMESCALE_PORT} dbname={ERAS_DB} user={ERAS_USER} password={ERAS_PW} sslmode=require") as timescale_db_conn:
+        with timescale_db_conn.cursor(name="timescale_cursor").copy("COPY classification_events FROM STDIN (format csv, delimiter '|', quote '\"')") as timescale_copy:
+            timescale_copy.write(open(f"prod_classifications_{output_file_no}.csv").read())
+    output_file_no += 1
+
+finish_time = datetime.now()
+print("CLASSIFICATIONS TIMESCALE backfill AFTER Time =", finish_time)
+
+

--- a/scripts/backfill_classifications_chunk_in_files.py
+++ b/scripts/backfill_classifications_chunk_in_files.py
@@ -18,11 +18,10 @@ FIRST_INGESTED_CLASSIFICATION_ID = os.getenv('FIRST_INGESTED_CLASSIFICATION_ID')
 start_time = datetime.now()
 print("CLASSIFICATIONS backfill BEFORE Time =", start_time)
 
+classifications_query = "select id::bigint as classification_id, created_at as event_time, updated_at as classification_updated_at, CASE WHEN metadata ->> 'started_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'started_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'started_at', 'YYYY-MM-DD HH24:MI:SS') END started_at,  CASE WHEN metadata ->> 'finished_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'finished_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'finished_at', 'YYYY-MM-DD HH24:MI:SS') END finished_at, project_id::bigint, workflow_id::bigint, user_id::bigint, array_remove(string_to_array(replace(replace(replace(metadata ->> 'user_group_ids', '[', ''), ']', ''), ' ', '' ), ','), 'null')::bigint[] as user_group_ids, EXTRACT(EPOCH FROM (CASE WHEN metadata ->> 'finished_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'finished_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'finished_at', 'YYYY-MM-DD HH24:MI:SS') END) - (CASE WHEN metadata ->> 'started_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'started_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'started_at', 'YYYY-MM-DD HH24:MI:SS') END)) as session_time, created_at, updated_at from classifications where id < %s order by id desc"
+
 offset = 0
 limit = 10000000
-
-classifications_query = "select id::bigint as classification_id, created_at as event_time, updated_at as classification_updated_at, CASE WHEN metadata ->> 'started_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'started_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'started_at', 'YYYY-MM-DD HH24:MI:SS') END started_at,  CASE WHEN metadata ->> 'finished_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'finished_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'finished_at', 'YYYY-MM-DD HH24:MI:SS') END finished_at, project_id::bigint, workflow_id::bigint, user_id::bigint, array_remove(string_to_array(replace(replace(replace(metadata ->> 'user_group_ids', '[', ''), ']', ''), ' ', '' ), ','), 'null')::bigint[] as user_group_ids, EXTRACT(EPOCH FROM (CASE WHEN metadata ->> 'finished_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'finished_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'finished_at', 'YYYY-MM-DD HH24:MI:SS') END) - (CASE WHEN metadata ->> 'started_at' ~'\d{1,2}\/\d{1,2}\/\d{2,4}' THEN to_timestamp(metadata ->> 'started_at', 'MM/DD/YYYY HH24:MI') ELSE TO_TIMESTAMP(metadata ->> 'started_at', 'YYYY-MM-DD HH24:MI:SS') END)) as session_time, created_at, updated_at from classifications where id < %s order by id desc limit %s"
-
 num_files = math.ceil(FIRST_INGESTED_CLASSIFICATION_ID/limit)
 
 while offset <= num_files:
@@ -35,7 +34,7 @@ while offset <= num_files:
 
   with psycopg.connect(f"host={PANOPTES_CONN} port={PANOPTES_PORT} dbname={PANOPTES_DB} user={PANOPTES_USER} password={PANOPTES_PW} sslmode=require") as panoptes_db_conn:
     with open(f"prod_classifications_{offset}.csv", "wb") as f:
-        with panoptes_db_conn.cursor(name="panoptes_cursor").copy(f"COPY ({classifications_query}) TO STDOUT WITH CSV HEADER", (FIRST_INGESTED_CLASSIFICATION_ID, limit)) as panoptes_copy:
+        with panoptes_db_conn.cursor(name="panoptes_cursor").copy(f"COPY ({classifications_query}) TO STDOUT WITH CSV HEADER", (FIRST_INGESTED_CLASSIFICATION_ID,)) as panoptes_copy:
             for data in panoptes_copy:
                 f.write(data)
     offset+= 1
@@ -45,7 +44,7 @@ print("PANOPTES Classification Copy over at ", finish_copy_time)
 print("TIMESCALE START COPY FROM CSV")
 
 output_file_no = 0
-while output_file_no < num_files:
+while output_file_no <= num_files:
     with psycopg.connect(f"host={TIMESCALE_CONNECTION} port={TIMESCALE_PORT} dbname={ERAS_DB} user={ERAS_USER} password={ERAS_PW} sslmode=require") as timescale_db_conn:
         with timescale_db_conn.cursor(name="timescale_cursor").copy("COPY classification_events FROM STDIN (format csv, delimiter '|', quote '\"')") as timescale_copy:
             timescale_copy.write(open(f"prod_classifications_{output_file_no}.csv").read())

--- a/scripts/backfill_classifications_chunk_in_files.py
+++ b/scripts/backfill_classifications_chunk_in_files.py
@@ -46,7 +46,7 @@ print("TIMESCALE START COPY FROM CSV")
 output_file_no = 0
 while output_file_no <= num_files:
     with psycopg.connect(f"host={TIMESCALE_CONNECTION} port={TIMESCALE_PORT} dbname={ERAS_DB} user={ERAS_USER} password={ERAS_PW} sslmode=require") as timescale_db_conn:
-        with timescale_db_conn.cursor(name="timescale_cursor").copy("COPY classification_events FROM STDIN (format csv, delimiter '|', quote '\"')") as timescale_copy:
+        with timescale_db_conn.cursor(name="timescale_cursor").copy("COPY classification_events FROM STDIN DELIMITER ',' CSV HEADER") as timescale_copy:
             timescale_copy.write(open(f"prod_classifications_{output_file_no}.csv").read())
     output_file_no += 1
 

--- a/scripts/copy_classifications_from_files.py
+++ b/scripts/copy_classifications_from_files.py
@@ -1,0 +1,27 @@
+import os
+import psycopg
+from datetime import datetime
+import math
+
+TIMESCALE_CONNECTION = os.getenv('TIMESCALE_CONNECTION')
+TIMESCALE_PORT = os.getenv('TIMESCALE_PORT')
+ERAS_DB = os.getenv('ERAS_DB')
+ERAS_USER = os.getenv('ERAS_USER')
+ERAS_PW = os.getenv('ERAS_PW')
+FIRST_INGESTED_CLASSIFICATION_ID = os.getenv('FIRST_INGESTED_CLASSIFICATION_ID')
+
+limit = 10000000
+num_files = math.ceil(FIRST_INGESTED_CLASSIFICATION_ID/limit)
+
+start_time = datetime.now()
+print("TIMESCALE START COPY FROM CSV BEFORE TIME =", start_time)
+
+output_file_no = 0
+while output_file_no <= num_files:
+    with psycopg.connect(f"host={TIMESCALE_CONNECTION} port={TIMESCALE_PORT} dbname={ERAS_DB} user={ERAS_USER} password={ERAS_PW} sslmode=require") as timescale_db_conn:
+        with timescale_db_conn.cursor(name="timescale_cursor").copy("COPY classification_events FROM STDIN DELIMITER ',' CSV HEADER") as timescale_copy:
+            timescale_copy.write(open(f"prod_classifications_{output_file_no}.csv").read())
+    output_file_no += 1
+
+finish_time = datetime.now()
+print("CLASSIFICATIONS TIMESCALE backfill AFTER Time =", finish_time)

--- a/scripts/save_classifications_chunk_in_files.py
+++ b/scripts/save_classifications_chunk_in_files.py
@@ -8,11 +8,6 @@ PANOPTES_PORT = os.getenv('PANOPTES_PORT')
 PANOPTES_DB = os.getenv('PANOPTES_DB')
 PANOPTES_USER = os.getenv('PANOPTES_USER')
 PANOPTES_PW = os.getenv('PANOPTES_PW')
-TIMESCALE_CONNECTION = os.getenv('TIMESCALE_CONNECTION')
-TIMESCALE_PORT = os.getenv('TIMESCALE_PORT')
-ERAS_DB = os.getenv('ERAS_DB')
-ERAS_USER = os.getenv('ERAS_USER')
-ERAS_PW = os.getenv('ERAS_PW')
 FIRST_INGESTED_CLASSIFICATION_ID = os.getenv('FIRST_INGESTED_CLASSIFICATION_ID')
 
 start_time = datetime.now()
@@ -41,16 +36,5 @@ while offset <= num_files:
 
 finish_copy_time = datetime.now()
 print("PANOPTES Classification Copy over at ", finish_copy_time)
-print("TIMESCALE START COPY FROM CSV")
-
-output_file_no = 0
-while output_file_no <= num_files:
-    with psycopg.connect(f"host={TIMESCALE_CONNECTION} port={TIMESCALE_PORT} dbname={ERAS_DB} user={ERAS_USER} password={ERAS_PW} sslmode=require") as timescale_db_conn:
-        with timescale_db_conn.cursor(name="timescale_cursor").copy("COPY classification_events FROM STDIN DELIMITER ',' CSV HEADER") as timescale_copy:
-            timescale_copy.write(open(f"prod_classifications_{output_file_no}.csv").read())
-    output_file_no += 1
-
-finish_time = datetime.now()
-print("CLASSIFICATIONS TIMESCALE backfill AFTER Time =", finish_time)
 
 


### PR DESCRIPTION
Keeping both old script and new script for record. 

Old script (where we use straight up COPY from source and COPY TO target db in one go), ended up taking a long time but also query cancels out and connection to db/s is lost. Because of how COPY works, its hard to debug where connection gets lost and because its an all in situation, we get no data copied. [this is backfill_classifications.py]

To mitigate, we did the following:
- split up the connections so that:
     1) from the source db, we save it all to csvs containing about 10,000,000 rows. 
     2) once all csvs are saved, close connection from source db, since we have everything we need from it. 
     3) connect to target db and copy from all the csvs saved. 
     4) then close connection from target db
[This is in ~~backfill_classifications_chunk_in_files.py~~ save_classifications_chunk_in_files.py then copy_classifications_from_files.py ]. 


Some minor changes:
- in backfill_classifications.py, moved the long 🍑  query into its own line. 
- updated the query to take care of the case where a classification's `metadata.user_groups` has `null` in it. (eg. `[1234, null, null]` ). This has shown up in some classifications while testing. 