### PR TITLE
add uniqueness constraints to cugs to take care of user_group_ids received from classrooms sometimes looking strange

### DIFF
--- a/app/models/classification_user_group.rb
+++ b/app/models/classification_user_group.rb
@@ -1,2 +1,3 @@
 class ClassificationUserGroup < ApplicationRecord
+  self.primary_keys = %i[event_time classification_id user_group_id user_id]
 end

--- a/db/migrate/20231023161237_add_unique_index_to_classification_user_groups.rb
+++ b/db/migrate/20231023161237_add_unique_index_to_classification_user_groups.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToClassificationUserGroups < ActiveRecord::Migration[7.0]
+  def change
+    execute <<~SQL
+      ALTER TABLE classification_user_groups ADD PRIMARY KEY(classification_id, event_time, user_group_id, user_id);
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_01_163827) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_23_161237) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "timescaledb"
@@ -31,13 +31,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_01_163827) do
     t.index ["event_time"], name: "classification_events_event_time_idx", order: :desc
   end
 
-  create_table "classification_user_groups", id: false, force: :cascade do |t|
-    t.bigint "classification_id"
+  create_table "classification_user_groups", primary_key: ["classification_id", "event_time", "user_group_id", "user_id"], force: :cascade do |t|
+    t.bigint "classification_id", null: false
     t.datetime "event_time", precision: nil, null: false
-    t.bigint "user_group_id"
+    t.bigint "user_group_id", null: false
     t.float "session_time"
     t.bigint "project_id"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.bigint "workflow_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/kinesis_stream_spec.rb
+++ b/spec/models/kinesis_stream_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe KinesisStream do
           kinesis_stream.create_events([classification_payload])
         end.to change(ClassificationUserGroup, :count).from(0).to(2)
       end
+
+      it 'creates one classification_user_group per each user_group and disregards duplicates on user_group_ids' do
+        classification_payload['data']['metadata']['user_group_ids'] = [1234, 1234]
+        expect do
+          kinesis_stream.create_events([classification_payload])
+        end.to change(ClassificationUserGroup, :count).from(0).to(1)
+      end
     end
   end
 end


### PR DESCRIPTION
This hasn't happened yet, but I did notice that some classifications coming from classrooms will send `metadata.user_group_ids` with duplicates. (Eg. user_group_ids: [1234, 1234, 1234]). 
Adding uniqueness constraints to classification_user_groups to ensure that duplicates do not get created for classification. 

Prework:
checked if there were any duplicates in staging and production:
SQL query:
```select * from classification_user_groups ou where (select count(*) from classification_user_groups inr where inr.classification_id = ou.classification_id and inr.user_group_id = ou.user_group_id) > 1```
there are 0 in both, but this could theoretically happen especially with finishing up the rest of ERAS backfill (Phase 4 Part 1, Creating Classification User Groups from backfilled classification_events)