### PR TITLE
add index by user_id on classifications

### DIFF
--- a/db/migrate/20240328183306_add_index_by_user_id_for_classifications.rb
+++ b/db/migrate/20240328183306_add_index_by_user_id_for_classifications.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Timescale currently does not support creating indexes concurrently. See: https://github.com/timescale/timescaledb/issues/504
+# This means that we cannot avoid write locks.
+# Timescale does offer adding indexes on a transaction per chunk basis.
+# See: https://docs.timescale.com/api/latest/hypertable/create_index/ for more details.
+
+class AddIndexByUserIdForClassifications < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    execute <<~SQL
+      CREATE INDEX index_classification_events_on_user_id ON classification_events(user_id) WITH (timescaledb.transaction_per_chunk);
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_06_170457) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_28_183306) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "timescaledb"
@@ -29,6 +29,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_06_170457) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["event_time"], name: "classification_events_event_time_idx", order: :desc
+    t.index ["user_id"], name: "index_classification_events_on_user_id"
   end
 
   create_table "classification_user_groups", primary_key: ["classification_id", "event_time", "user_group_id", "user_id"], force: :cascade do |t|


### PR DESCRIPTION
Add index by user_id on classification_events. Currently, we are indexing by `event_time` as well as our composite primary key which automatically creates index by pkey (a combo of `event_time` and `classification_id`). 

Originally, classification_events was designed without the index by `user_id` mainly because 
- ERAS' responsibility is to be a classification/comment counter (of when and how many) 
- ERAS leaves the responsibility of counting by `user_id` to the materialized view/continuous aggregate. (DailyClassificationCountsPerUser____) 

As we look into sync script (syncing newly added group members and their classifications), we now care about the case where users who are supposed to belong to a user_group but did not join the user_group (and have classifications that should be counted to the user_group). And therefore we need to search classification_events by user_id. This search is currently inefficient since it has to go through sequential scans of the whole hypertable in order to receive results. 

**NOTE**
-Timescale currently does not support creating indexes concurrently. This means that we cannot avoid write locks.
- HOWEVER, Timescale DOES offer adding indexes on a transaction per chunk basis which extends postgres' `CREATE INDEX` 
See: https://docs.timescale.com/api/latest/hypertable/create_index/ for more details.