### PR TITLE
Update queries for workflow counts

### DIFF
--- a/app/models/classification_counts/hourly_workflow_classification_count.rb
+++ b/app/models/classification_counts/hourly_workflow_classification_count.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ClassificationCounts
+    class HourlyWorkflowClassificationCount < ApplicationRecord
+      self.table_name = 'hourly_classification_count_per_workflow'
+      attribute :classification_count, :integer
+
+      def readonly?
+        true
+      end
+    end
+  end

--- a/app/models/classification_counts/hourly_workflow_classification_count.rb
+++ b/app/models/classification_counts/hourly_workflow_classification_count.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module ClassificationCounts
-    class HourlyWorkflowClassificationCount < ApplicationRecord
-      self.table_name = 'hourly_classification_count_per_workflow'
-      attribute :classification_count, :integer
+  class HourlyWorkflowClassificationCount < ApplicationRecord
+    self.table_name = 'hourly_classification_count_per_workflow'
+    attribute :classification_count, :integer
 
-      def readonly?
-        true
-      end
+    def readonly?
+      true
     end
   end
+end

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -46,7 +46,7 @@ class CountClassifications
 
     if scoped_upto_yesterday.blank?
       # append new entry where period is start of the week
-      todays_classifications[0].period = start_of_current_period(period)
+      todays_classifications[0].period = start_of_current_period(period)&.to_time&.utc
       return todays_classifications
     end
 

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -57,7 +57,7 @@ class CountClassifications
     # we check if the current date is part of the period
     # if so, we add the count to the most recent period pulled from db
     # if not, we append as a new entry for the current period
-    if is_today_part_of_recent_period?(most_recent_date_from_scoped, period)
+    if today_part_of_recent_period?(most_recent_date_from_scoped, period)
       add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
     else
       todays_classifications[0].period = start_of_current_period(period).to_time.utc
@@ -80,7 +80,7 @@ class CountClassifications
     end
   end
 
-  def is_today_part_of_recent_period?(most_recent_date, period)
+  def today_part_of_recent_period?(most_recent_date, period)
     most_recent_date == start_of_current_period(period)
   end
 

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -35,7 +35,6 @@ class CountClassifications
   def include_today_to_scoped(scoped_upto_yesterday, workflow_id, period)
     todays_classifications = current_date_workflow_classifications(workflow_id)
     most_recent_date_from_scoped = scoped_upto_yesterday[-1].period&.to_date
-    most_recent_count = scoped_upto_yesterday[-1].count
     if is_today_part_of_recent_period?(most_recent_date_from_scoped, period)
       add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
     else
@@ -46,11 +45,11 @@ class CountClassifications
   def is_today_part_of_recent_period?(most_recent_date, period)
     case period
     when 'day'
-      false
+      Date.today == most_recent_date
     when 'week'
       (Date.today - most_recent_date).to_i < 7
     when 'month'
-      Date.today.month == most_recent_date.month
+      (Date.today.month == most_recent_date.month) && (Date.today.year == most_recent_date.year)
     when 'year'
       Date.today.year == most_recent_date.year
     end

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -41,12 +41,13 @@ class CountClassifications
   end
 
   def include_today_to_scoped(scoped_upto_yesterday, workflow_id, period)
+    period = 'year' if period.nil?
     todays_classifications = current_date_workflow_classifications(workflow_id)
     return scoped_upto_yesterday if todays_classifications.blank?
 
     if scoped_upto_yesterday.blank?
-      # append new entry where period is start of the week
-      todays_classifications[0].period = start_of_current_period(period)&.to_time&.utc
+      # append new entry where period is start of the period
+      todays_classifications[0].period = start_of_current_period(period).to_time.utc
       return todays_classifications
     end
 
@@ -59,6 +60,7 @@ class CountClassifications
     if is_today_part_of_recent_period?(most_recent_date_from_scoped, period)
       add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
     else
+      todays_classifications[0].period = start_of_current_period(period).to_time.utc
       append_today_to_scoped(scoped_upto_yesterday, todays_classifications)
     end
   end

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -13,7 +13,19 @@ class CountClassifications
     scoped = @counts
     scoped = filter_by_workflow_id(scoped, params[:workflow_id])
     scoped = filter_by_project_id(scoped, params[:project_id])
-    filter_by_date_range(scoped, params[:start_date], params[:end_date])
+    if params[:workflow_id].present?
+      if end_date_includes_today?(params[:end_date])
+        scoped_upto_yesterday = filter_by_date_range(scoped, params[:start_date], Date.yesterday.to_s)
+
+        puts scoped_upto_yesterday
+        scoped = append_to_scoped(scoped_upto_yesterday, params[:workflow_id], params[:period])
+      else
+        scoped = filter_by_date_range(scoped, params[:start_date], params[:end_date])
+      end
+    else
+      scoped = filter_by_date_range(scoped, params[:start_date], params[:end_date])
+    end
+    return scoped
   end
 
   private
@@ -22,12 +34,54 @@ class CountClassifications
     relation.select(select_and_time_bucket_by(period, 'classification')).group('period').order('period')
   end
 
-  def end_date_includes_today?(params)
-    includes_today = true
-    if params[:end_date]
-      end_date = Date.parse(params[:end_date])
-      includes_today = end_date >= Date.today
+  def append_to_scoped(scoped_upto_yesterday, workflow_id, period)
+    todays_classifications = current_date_workflow_classifications(workflow_id)
+    most_recent_period_from_scoped = scoped_upto_yesterday[-1].period&.to_date
+    most_recent_count = scoped_upto_yesterday[-1].count
+    case period
+    when 'day'
+      scoped_upto_yesterday + todays_classifications
+    when 'week'
+      if (Date.today - most_recent_period_from_scoped).to_i < 7
+        add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
+      else
+        scoped_upto_yesterday + todays_classifications
+      end
+    when 'month'
+      if (Date.today.month == most_recent_period_from_scoped.month)
+        add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
+      else
+        scoped_upto_yesterday + todays_classifications
+      end
+    when 'year'
+      if (Date.today.year == most_recent_period_from_scoped.year)
+        add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
+      else
+        scoped_upto_yesterday + todays_classifications
+      end
     end
+  end
+
+  def add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
+    current_period_counts = scoped_upto_yesterday[-1].count + todays_classifications[0].count
+    scoped_upto_yesterday[-1].count = current_period_counts
+    scoped_upto_yesterday
+  end
+
+  def current_date_workflow_classifications(workflow_id)
+    current_day_str = Date.today.to_s
+    current_hourly_classifications = ClassificationCounts::HourlyWorkflowClassificationCount.select("time_bucket('1 day', hour) AS period, SUM(classification_count)::integer AS count").group('period').order('period').where("hour >= '#{current_day_str}'")
+    filter_by_workflow_id(current_hourly_classifications, workflow_id)
+  end
+
+  # if period is day append today's result as a result
+  # if period is week/month or year first check if today is in the week or month or year
+  # if it is, add the count to the last count
+  # if it isn't add a new entry to result
+
+  def end_date_includes_today?(end_date)
+    includes_today = true
+    includes_today = Date.parse(end_date) >= Date.today if end_date.present?
     return includes_today
   end
 

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -31,7 +31,7 @@ class CountClassifications
     else
       scoped = filter_by_date_range(scoped, params[:start_date], params[:end_date])
     end
-    return scoped
+    scoped
   end
 
   private
@@ -103,7 +103,7 @@ class CountClassifications
   def end_date_includes_today?(end_date)
     includes_today = true
     includes_today = Date.parse(end_date) >= Date.today if end_date.present?
-    return includes_today
+    includes_today
   end
 
   def relation(params)

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -22,6 +22,15 @@ class CountClassifications
     relation.select(select_and_time_bucket_by(period, 'classification')).group('period').order('period')
   end
 
+  def end_date_includes_today?(params)
+    includes_today = true
+    if params[:end_date]
+      end_date = Date.parse(params[:end_date])
+      includes_today = end_date >= Date.today
+    end
+    return includes_today
+  end
+
   def relation(params)
     if params[:workflow_id]
       ClassificationCounts::DailyWorkflowClassificationCount

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -16,7 +16,7 @@ class CountClassifications
     if params[:workflow_id].present?
       if end_date_includes_today?(params[:end_date])
         scoped_upto_yesterday = filter_by_date_range(scoped, params[:start_date], Date.yesterday.to_s)
-        scoped = append_to_scoped(scoped_upto_yesterday, params[:workflow_id], params[:period])
+        scoped = include_today_to_scoped(scoped_upto_yesterday, params[:workflow_id], params[:period])
       else
         scoped = filter_by_date_range(scoped, params[:start_date], params[:end_date])
       end
@@ -32,38 +32,38 @@ class CountClassifications
     relation.select(select_and_time_bucket_by(period, 'classification')).group('period').order('period')
   end
 
-  def append_to_scoped(scoped_upto_yesterday, workflow_id, period)
+  def include_today_to_scoped(scoped_upto_yesterday, workflow_id, period)
     todays_classifications = current_date_workflow_classifications(workflow_id)
-    most_recent_period_from_scoped = scoped_upto_yesterday[-1].period&.to_date
+    most_recent_date_from_scoped = scoped_upto_yesterday[-1].period&.to_date
     most_recent_count = scoped_upto_yesterday[-1].count
-    case period
-    when 'day'
-      scoped_upto_yesterday + todays_classifications
-    when 'week'
-      if (Date.today - most_recent_period_from_scoped).to_i < 7
-        add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
-      else
-        scoped_upto_yesterday + todays_classifications
-      end
-    when 'month'
-      if (Date.today.month == most_recent_period_from_scoped.month)
-        add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
-      else
-        scoped_upto_yesterday + todays_classifications
-      end
-    when 'year'
-      if (Date.today.year == most_recent_period_from_scoped.year)
-        add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
-      else
-        scoped_upto_yesterday + todays_classifications
-      end
+    if is_today_part_of_recent_period?(most_recent_date_from_scoped, period)
+      add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
+    else
+      append_today_to_scoped(scoped_upto_yesterday, todays_classifications)
     end
   end
 
-  def add_todays_counts_to_recent_period_counts(scoped_upto_yesterday, todays_classifications)
-    current_period_counts = scoped_upto_yesterday[-1].count + todays_classifications[0].count
-    scoped_upto_yesterday[-1].count = current_period_counts
-    scoped_upto_yesterday
+  def is_today_part_of_recent_period?(most_recent_date, period)
+    case period
+    when 'day'
+      false
+    when 'week'
+      (Date.today - most_recent_date).to_i < 7
+    when 'month'
+      Date.today.month == most_recent_date.month
+    when 'year'
+      Date.today.year == most_recent_date.year
+    end
+  end
+
+  def append_today_to_scoped(count_records_up_to_yesterday, todays_count)
+    count_records_up_to_yesterday + todays_count
+  end
+
+  def add_todays_counts_to_recent_period_counts(count_records_up_to_yesterday, todays_counts
+    current_period_counts = count_records_up_to_yesterday[-1].count + todays_count[0].count
+    count_records_up_to_yesterday[-1].count = current_period_counts
+    count_records_up_to_yesterday
   end
 
   def current_date_workflow_classifications(workflow_id)

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -16,8 +16,6 @@ class CountClassifications
     if params[:workflow_id].present?
       if end_date_includes_today?(params[:end_date])
         scoped_upto_yesterday = filter_by_date_range(scoped, params[:start_date], Date.yesterday.to_s)
-
-        puts scoped_upto_yesterday
         scoped = append_to_scoped(scoped_upto_yesterday, params[:workflow_id], params[:period])
       else
         scoped = filter_by_date_range(scoped, params[:start_date], params[:end_date])

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -25,10 +25,6 @@ class CountClassifications
     if params[:workflow_id].present?
       if end_date_includes_today?(params[:end_date])
         scoped_upto_yesterday = filter_by_date_range(scoped, params[:start_date], Date.yesterday.to_s)
-        puts "MDY114 LAST"
-        puts scoped_upto_yesterday
-        puts scoped_upto_yesterday.blank?
-        # puts scoped_upto_yesterday.last.period
         scoped = include_today_to_scoped(scoped_upto_yesterday, params[:workflow_id], params[:period])
       else
         scoped = filter_by_date_range(scoped, params[:start_date], params[:end_date])
@@ -47,16 +43,10 @@ class CountClassifications
 
   def include_today_to_scoped(scoped_upto_yesterday, workflow_id, period)
     todays_classifications = current_date_workflow_classifications(workflow_id)
-    puts "MDY114 TDOAYS CLASSIFICATIONS"
-    puts todays_classifications.blank?
-    # todays_classifications
     return scoped_upto_yesterday if todays_classifications.blank?
 
     if scoped_upto_yesterday.blank?
-      puts todays_classifications
-      puts "mdy114 hits here"
       # append new entry where period is start of the week
-      puts start_of_current_period(period)
       todays_classifications[0].period = start_of_current_period(period)
       return todays_classifications
     end
@@ -90,16 +80,17 @@ class CountClassifications
   end
 
   def is_today_part_of_recent_period?(most_recent_date, period)
-    case period
-    when 'day'
-      Date.today == most_recent_date
-    when 'week'
-      (Date.today - most_recent_date).to_i < 7
-    when 'month'
-      (Date.today.month == most_recent_date.month) && (Date.today.year == most_recent_date.year)
-    when 'year'
-      Date.today.year == most_recent_date.year
-    end
+    most_recent_date == start_of_current_period(period)
+    # case period
+    # when 'day'
+    #   Date.today == most_recent_date
+    # when 'week'
+    #   (Date.today - most_recent_date).to_i < 7
+    # when 'month'
+    #   (Date.today.month == most_recent_date.month) && (Date.today.year == most_recent_date.year)
+    # when 'year'
+    #   Date.today.year == most_recent_date.year
+    # end
   end
 
   def append_today_to_scoped(count_records_up_to_yesterday, todays_count)

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -16,7 +16,6 @@ class CountClassifications
     # Because of how the FE, calls out to this endpoint when querying for a project's workflow's classifications count
     # And because of our use of Real Time Aggregates
     # Querying the DailyClassificationCountByWorkflow becomes not as performant
-
     # Because we are limited in resources, we do the following mitigaion for ONLY querying workflow classification counts:
     # 1. Create a New HourlyClassificationCountByWorkflow which is RealTime and Create a Data Retention for this new aggregate (this should limit the amount of data the query planner has to sift through)
     # 2. Turn off Real Time aggreation for the DailyClassificationCount
@@ -81,16 +80,6 @@ class CountClassifications
 
   def is_today_part_of_recent_period?(most_recent_date, period)
     most_recent_date == start_of_current_period(period)
-    # case period
-    # when 'day'
-    #   Date.today == most_recent_date
-    # when 'week'
-    #   (Date.today - most_recent_date).to_i < 7
-    # when 'month'
-    #   (Date.today.month == most_recent_date.month) && (Date.today.year == most_recent_date.year)
-    # when 'year'
-    #   Date.today.year == most_recent_date.year
-    # end
   end
 
   def append_today_to_scoped(count_records_up_to_yesterday, todays_count)
@@ -108,11 +97,6 @@ class CountClassifications
     current_hourly_classifications = ClassificationCounts::HourlyWorkflowClassificationCount.select("time_bucket('1 day', hour) AS period, SUM(classification_count)::integer AS count").group('period').order('period').where("hour >= '#{current_day_str}'")
     filter_by_workflow_id(current_hourly_classifications, workflow_id)
   end
-
-  # if period is day append today's result as a result
-  # if period is week/month or year first check if today is in the week or month or year
-  # if it is, add the count to the last count
-  # if it isn't add a new entry to result
 
   def end_date_includes_today?(end_date)
     includes_today = true

--- a/app/queries/count_classifications.rb
+++ b/app/queries/count_classifications.rb
@@ -60,7 +60,7 @@ class CountClassifications
     count_records_up_to_yesterday + todays_count
   end
 
-  def add_todays_counts_to_recent_period_counts(count_records_up_to_yesterday, todays_counts
+  def add_todays_counts_to_recent_period_counts(count_records_up_to_yesterday, todays_count)
     current_period_counts = count_records_up_to_yesterday[-1].count + todays_count[0].count
     count_records_up_to_yesterday[-1].count = current_period_counts
     count_records_up_to_yesterday

--- a/db/migrate/20240926225916_create_hourly_workflow_classification_count.rb
+++ b/db/migrate/20240926225916_create_hourly_workflow_classification_count.rb
@@ -1,0 +1,25 @@
+class CreateHourlyWorkflowClassificationCount < ActiveRecord::Migration[7.0]
+  # we have to disable the migration transaction because creating materialized views within it is not allowed.
+
+  # Due to how the front end pulls project stats (and workflow stats) all in one go, we hit performance issues; especially if a project has multiple workflows.
+  # We have discovered that having a non-realtime/materialized only continous aggregate for our daily workflow count cagg is more performant than real time.
+  # We plan to do the following:
+  # - Update the daily_classification_count_per_workflow to be materialized only (i.e. non-realtime)
+  # - Create a subsequent realtime cagg that buckets hourly that we will create data retention policies for. The plan is for up to 72 hours worth of hourly workflow classification counts of data.
+  # - Update workflow query to first query the daily counts first and the query the hourly counts for just the specific date of NOw.
+  disable_ddl_transaction!
+  def change
+    execute <<~SQL
+      create materialized view hourly_classification_count_per_workflow
+      with (
+        timescaledb.continuous
+      ) as
+      select
+        time_bucket('1 hour', event_time) as hour,
+        workflow_id,
+        count(*) as classification_count
+      from classification_events where event_time > now() - INTERVAL '5 days'
+      group by hour, workflow_id;
+    SQL
+  end
+end

--- a/db/migrate/20240926225916_create_hourly_workflow_classification_count.rb
+++ b/db/migrate/20240926225916_create_hourly_workflow_classification_count.rb
@@ -10,7 +10,7 @@ class CreateHourlyWorkflowClassificationCount < ActiveRecord::Migration[7.0]
   # - Create a subsequent realtime cagg that buckets hourly that we will create data retention policies for. The plan is for up to 72 hours worth of hourly workflow classification counts of data.
   # - Update workflow query to first query the daily counts first and the query the hourly counts for just the specific date of now.
   disable_ddl_transaction!
-  def change
+  def up
     execute <<~SQL
       create materialized view hourly_classification_count_per_workflow
       with (
@@ -22,6 +22,12 @@ class CreateHourlyWorkflowClassificationCount < ActiveRecord::Migration[7.0]
         count(*) as classification_count
       from classification_events where event_time > now() - INTERVAL '5 days'
       group by hour, workflow_id;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      DROP materialized view hourly_classification_count_per_workflow;
     SQL
   end
 end

--- a/db/migrate/20240926225916_create_hourly_workflow_classification_count.rb
+++ b/db/migrate/20240926225916_create_hourly_workflow_classification_count.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true.
+
 class CreateHourlyWorkflowClassificationCount < ActiveRecord::Migration[7.0]
   # we have to disable the migration transaction because creating materialized views within it is not allowed.
 

--- a/db/migrate/20240926225916_create_hourly_workflow_classification_count.rb
+++ b/db/migrate/20240926225916_create_hourly_workflow_classification_count.rb
@@ -6,7 +6,7 @@ class CreateHourlyWorkflowClassificationCount < ActiveRecord::Migration[7.0]
   # We plan to do the following:
   # - Update the daily_classification_count_per_workflow to be materialized only (i.e. non-realtime)
   # - Create a subsequent realtime cagg that buckets hourly that we will create data retention policies for. The plan is for up to 72 hours worth of hourly workflow classification counts of data.
-  # - Update workflow query to first query the daily counts first and the query the hourly counts for just the specific date of NOw.
+  # - Update workflow query to first query the daily counts first and the query the hourly counts for just the specific date of now.
   disable_ddl_transaction!
   def change
     execute <<~SQL

--- a/db/migrate/20240926231010_add_refresh_policy_for_hourly_workflow_count.rb
+++ b/db/migrate/20240926231010_add_refresh_policy_for_hourly_workflow_count.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+
 class AddRefreshPolicyForHourlyWorkflowCount < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
   def change

--- a/db/migrate/20240926231010_add_refresh_policy_for_hourly_workflow_count.rb
+++ b/db/migrate/20240926231010_add_refresh_policy_for_hourly_workflow_count.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 class AddRefreshPolicyForHourlyWorkflowCount < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
   def change

--- a/db/migrate/20240926231010_add_refresh_policy_for_hourly_workflow_count.rb
+++ b/db/migrate/20240926231010_add_refresh_policy_for_hourly_workflow_count.rb
@@ -1,0 +1,8 @@
+class AddRefreshPolicyForHourlyWorkflowCount < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def change
+    execute <<~SQL
+      SELECT add_continuous_aggregate_policy('hourly_classification_count_per_workflow',start_offset => INTERVAL '5 days', end_offset => INTERVAL '30 minutes', schedule_interval => INTERVAL '1 h');
+    SQL
+  end
+end

--- a/db/migrate/20240926231010_add_refresh_policy_for_hourly_workflow_count.rb
+++ b/db/migrate/20240926231010_add_refresh_policy_for_hourly_workflow_count.rb
@@ -2,9 +2,15 @@
 
 class AddRefreshPolicyForHourlyWorkflowCount < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
-  def change
+  def up
     execute <<~SQL
       SELECT add_continuous_aggregate_policy('hourly_classification_count_per_workflow',start_offset => INTERVAL '5 days', end_offset => INTERVAL '30 minutes', schedule_interval => INTERVAL '1 h');
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      SELECT remove_continuous_aggregate_policy('hourly_classification_count_per_workflow');
     SQL
   end
 end

--- a/db/migrate/20240926231325_create_data_retention_policy_for_hourly_workflow_count.rb
+++ b/db/migrate/20240926231325_create_data_retention_policy_for_hourly_workflow_count.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateDataRetentionPolicyForHourlyWorkflowCount < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
   def change

--- a/db/migrate/20240926231325_create_data_retention_policy_for_hourly_workflow_count.rb
+++ b/db/migrate/20240926231325_create_data_retention_policy_for_hourly_workflow_count.rb
@@ -2,9 +2,15 @@
 
 class CreateDataRetentionPolicyForHourlyWorkflowCount < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
-  def change
+  def up
     execute <<~SQL
       SELECT add_retention_policy('hourly_classification_count_per_workflow', drop_after => INTERVAL '3 days');
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      SELECT remove_retention_policy('hourly_classification_count_per_workflow');
     SQL
   end
 end

--- a/db/migrate/20240926231325_create_data_retention_policy_for_hourly_workflow_count.rb
+++ b/db/migrate/20240926231325_create_data_retention_policy_for_hourly_workflow_count.rb
@@ -1,0 +1,8 @@
+class CreateDataRetentionPolicyForHourlyWorkflowCount < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def change
+    execute <<~SQL
+      SELECT add_retention_policy('hourly_classification_count_per_workflow', drop_after => INTERVAL '3 days');
+    SQL
+  end
+end

--- a/db/migrate/20240926233924_alter_daily_workflow_classification_count_to_materialized_only.rb
+++ b/db/migrate/20240926233924_alter_daily_workflow_classification_count_to_materialized_only.rb
@@ -1,0 +1,8 @@
+class AlterDailyWorkflowClassificationCountToMaterializedOnly < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def change
+    execute <<~SQL
+      ALTER MATERIALIZED VIEW daily_classification_count_per_workflow set (timescaledb.materialized_only = true);
+    SQL
+  end
+end

--- a/db/migrate/20240926233924_alter_daily_workflow_classification_count_to_materialized_only.rb
+++ b/db/migrate/20240926233924_alter_daily_workflow_classification_count_to_materialized_only.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AlterDailyWorkflowClassificationCountToMaterializedOnly < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
   def up

--- a/db/migrate/20240926233924_alter_daily_workflow_classification_count_to_materialized_only.rb
+++ b/db/migrate/20240926233924_alter_daily_workflow_classification_count_to_materialized_only.rb
@@ -1,8 +1,14 @@
 class AlterDailyWorkflowClassificationCountToMaterializedOnly < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
-  def change
+  def up
     execute <<~SQL
       ALTER MATERIALIZED VIEW daily_classification_count_per_workflow set (timescaledb.materialized_only = true);
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      ALTER MATERIALIZED VIEW daily_classification_count_per_workflow set (timescaledb.materialized_only = false);
     SQL
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_28_183306) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_26_233924) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "timescaledb"

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -35,7 +35,7 @@ namespace :db do
 
     ActiveRecord::Base.connection.execute <<-SQL
       CREATE MATERIALIZED VIEW IF NOT EXISTS daily_classification_count_per_workflow
-      WITH (timescaledb.continuous, timescaledb.materialized_only) AS
+      WITH (timescaledb.continuous) AS
       SELECT time_bucket('1 day', event_time) AS day,
       workflow_id,
             count(*) as classification_count

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -35,7 +35,7 @@ namespace :db do
 
     ActiveRecord::Base.connection.execute <<-SQL
       CREATE MATERIALIZED VIEW IF NOT EXISTS daily_classification_count_per_workflow
-      WITH (timescaledb.continuous) AS
+      WITH (timescaledb.continuous, timescaledb.materialized_only) AS
       SELECT time_bucket('1 day', event_time) AS day,
       workflow_id,
             count(*) as classification_count
@@ -183,6 +183,16 @@ namespace :db do
       FROM classification_user_groups WHERE user_group_id IS NOT NULL
       GROUP BY day, user_group_id, user_id, workflow_id;
     SQL
+
+    ActiveRecord::Base.connection.execute <<-SQL
+      CREATE MATERIALIZED VIEW IF NOT EXISTS hourly_classification_count_per_workflow
+      WITH (timescaledb.continuous) AS
+      SELECT time_bucket('1 hour', event_time) AS hour,
+      workflow_id,
+            count(*) as classification_count
+      FROM classification_events
+      GROUP BY hour, workflow_id;
+    SQL
   end
 
   desc 'Drop Continuous Aggregates Views'
@@ -203,6 +213,7 @@ namespace :db do
     DROP MATERIALIZED VIEW IF EXISTS daily_group_classification_count_and_time_per_user CASCADE;
     DROP MATERIALIZED VIEW IF EXISTS daily_group_classification_count_and_time_per_user_per_project CASCADE;
     DROP MATERIALIZED VIEW IF EXISTS daily_group_classification_count_and_time_per_user_per_workflow CASCADE;
+    DROP MATERIALIZED VIEW IF EXISTS hourly_classification_count_per_workflow CASCADE;
     SQL
   end
 

--- a/spec/queries/count_classifications_spec.rb
+++ b/spec/queries/count_classifications_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe CountClassifications do
             end
 
             context 'when current day is part of the most recently pulled period' do
-              it 'adds the most recent period to the most recently pulled period counts' do
+              it 'adds the current day counts to the most recently pulled period counts' do
                 create(:classification_with_diff_workflow, classification_id: 1000, event_time: Date.new(2022, 1, 2))
                 expect(counts.length).to eq(1)
                 # the 2 classifications counted is the one created in L170 as well as diff_workflow_event classification.

--- a/spec/queries/count_classifications_spec.rb
+++ b/spec/queries/count_classifications_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe CountClassifications do
 
             context 'when current day is part of the most recently pulled period' do
               it 'adds the most recent period to the most recently pulled period counts' do
-                create(:classification_with_diff_workflow, classification_id: 1000, event_time: Date.new(2022,01,02))
+                create(:classification_with_diff_workflow, classification_id: 1000, event_time: Date.new(2022, 1, 2))
                 expect(counts.length).to eq(1)
                 expect(counts[0].count).to eq(2)
                 expect(counts[0].period).to eq(Date.today.at_beginning_of_year)
@@ -176,7 +176,7 @@ RSpec.describe CountClassifications do
 
             context 'when current day is not part of the most recently pulled period' do
               it 'appends a new entry to scoped from HourlyWorkflowCount query' do
-                create(:classification_with_diff_workflow, classification_id: 1000, event_time: Date.new(2021,01,02))
+                create(:classification_with_diff_workflow, classification_id: 1000, event_time: Date.new(2021, 1, 2))
                 expect(counts.length).to eq(2)
                 counts.each { |c| expect(c.count).to eq(1) }
                 expect(counts[0].class).to be(ClassificationCounts::DailyWorkflowClassificationCount)

--- a/spec/queries/count_classifications_spec.rb
+++ b/spec/queries/count_classifications_spec.rb
@@ -169,6 +169,7 @@ RSpec.describe CountClassifications do
               it 'adds the most recent period to the most recently pulled period counts' do
                 create(:classification_with_diff_workflow, classification_id: 1000, event_time: Date.new(2022, 1, 2))
                 expect(counts.length).to eq(1)
+                # the 2 classifications counted is the one created in L170 as well as diff_workflow_event classification.
                 expect(counts[0].count).to eq(2)
                 expect(counts[0].period).to eq(Date.today.at_beginning_of_year)
               end

--- a/spec/queries/count_classifications_spec.rb
+++ b/spec/queries/count_classifications_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe CountClassifications do
 
     context 'when params[:workflow_id] present' do
       context 'when params[:end_date] is before current date' do
-        it 'returns counts from DailyWorkflowClassificationCount'do
+        it 'returns counts from DailyWorkflowClassificationCount' do
           yesterday = Date.today - 1
           params[:workflow_id] = diff_time_event.workflow_id.to_s
           params[:end_date] = yesterday.to_s
@@ -149,7 +149,7 @@ RSpec.describe CountClassifications do
 
         context 'when there are classifications up to previous day' do
           context 'when there are 0 classifications for current day' do
-            let!(:classification_created_yesterday_diff_workflow) { create(:classification_created_yesterday, workflow_id: 4, classification_id: 100)}
+            let!(:classification_created_yesterday_diff_workflow) { create(:classification_created_yesterday, workflow_id: 4, classification_id: 100) }
             it 'returns from DailyWorkflowCount (scoped up to yesterday)' do
               params[:workflow_id] = classification_created_yesterday_diff_workflow.workflow_id.to_s
               expect(counts.model).to be(ClassificationCounts::DailyWorkflowClassificationCount)
@@ -160,7 +160,7 @@ RSpec.describe CountClassifications do
 
           context 'when there are classifications for current day' do
             before do
-              allow(Date).to receive(:today).and_return Date.new(2022,10,21)
+              allow(Date).to receive(:today).and_return Date.new(2022, 10, 21)
               params[:workflow_id] = diff_workflow_event.workflow_id.to_s
               params[:period] = 'year'
             end

--- a/spec/queries/count_classifications_spec.rb
+++ b/spec/queries/count_classifications_spec.rb
@@ -91,5 +91,49 @@ RSpec.describe CountClassifications do
       expect(counts.length).to eq(1)
       expect(counts[0].count).to eq(1)
     end
+
+    context 'when params[:workflow_id] present' do
+      context 'when params[:end_date] is before current date' do
+        it 'returns counts of events of given date range from DailyWorkflowCounts' do
+
+        end
+      end
+
+      context 'when params[:end_date] includes current date' do
+        context 'when no classification count up to previous day' do
+          context 'when no classifications for current day' do
+            it 'returns from DailyWorkflowCount' do
+            end
+          end
+
+          context 'when there are classifications for current day' do
+            it 'returns from HourlyWorkflowCount' do
+            end
+
+            it 'returns proper start of period' do
+            end
+          end
+        end
+
+        context 'when there are classifications up to previous day' do
+          context 'when there are no classifications for current day' do
+            it 'returns from DailyWorkflowCount (scoped up to yesterday)' do
+            end
+          end
+
+          context 'when there are classifications for current day' do
+            context 'when current day is part of the most recently pulled period' do
+              it 'adds the most recent period to the most recently pulled period counts' do
+              end
+            end
+
+            context 'when current day is not part of the most recently pulled period' do
+              it 'appends a new entry to scoped from HourlyWorkflowCount query' do
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/queries/count_classifications_spec.rb
+++ b/spec/queries/count_classifications_spec.rb
@@ -94,15 +94,27 @@ RSpec.describe CountClassifications do
 
     context 'when params[:workflow_id] present' do
       context 'when params[:end_date] is before current date' do
-        it 'returns counts of events of given date range from DailyWorkflowCounts' do
-
+        it 'returns counts from DailyWorkflowClassificationCount'do
+          yesterday = Date.today - 1
+          params[:workflow_id] = diff_time_event.workflow_id.to_s
+          params[:end_date] = yesterday.to_s
+          counts = count_classifications.call(params)
+          expect(counts.model).to be(ClassificationCounts::DailyWorkflowClassificationCount)
+          expect(counts.length).to eq(1)
+          expect(counts[0].count).to eq(1)
         end
       end
 
       context 'when params[:end_date] includes current date' do
         context 'when no classification count up to previous day' do
           context 'when no classifications for current day' do
-            it 'returns from DailyWorkflowCount' do
+            it 'returns from DailyWorkflowClassificationCount' do
+              # Select a workflow id that has no classification
+              params[:workflow_id] = '100'
+              params[:end_date] = Date.today.to_s
+              counts = count_classifications.call(params)
+              expect(counts.model).to be(ClassificationCounts::DailyWorkflowClassificationCount)
+              expect(counts.length).to eq(0)
             end
           end
 

--- a/spec/queries/count_classifications_spec.rb
+++ b/spec/queries/count_classifications_spec.rb
@@ -22,15 +22,14 @@ RSpec.describe CountClassifications do
   end
 
   describe 'select_and_time_bucket_by' do
+    let(:counts) { count_classifications.call(params) }
     it 'buckets counts by year by default' do
-      counts = count_classifications.call(params)
       expected_select_query = "SELECT time_bucket('1 year', day) AS period, SUM(classification_count)::integer AS count FROM \"daily_classification_count\" GROUP BY period ORDER BY period"
       expect(counts.to_sql).to eq(expected_select_query)
     end
 
     it 'buckets counts by given period' do
       params[:period] = 'week'
-      counts = count_classifications.call(params)
       expected_select_query = "SELECT time_bucket('1 week', day) AS period, SUM(classification_count)::integer AS count FROM \"daily_classification_count\" GROUP BY period ORDER BY period"
       expect(counts.to_sql).to eq(expected_select_query)
     end
@@ -41,13 +40,13 @@ RSpec.describe CountClassifications do
     let!(:diff_workflow_event) { create(:classification_with_diff_workflow) }
     let!(:diff_project_event) { create(:classification_with_diff_project) }
     let!(:diff_time_event) { create(:classification_created_yesterday) }
+    let(:counts) { count_classifications.call(params) }
 
     it_behaves_like 'is filterable by workflow'
     it_behaves_like 'is filterable by project'
     it_behaves_like 'is filterable by date range'
 
     it 'returns counts of all events when no params given' do
-      counts = count_classifications.call(params)
       # because default is bucket by year and all data created in the same year, we expect counts to look something like
       # [<ClassificationCounts::DailyClassificationCount period: 01-01-2023, count: 4>]
       current_year = Date.today.year
@@ -58,7 +57,6 @@ RSpec.describe CountClassifications do
 
     it 'returns counts bucketed by given period' do
       params[:period] = 'day'
-      counts = count_classifications.call(params)
       expect(counts.length).to eq(2)
       expect(counts[0].count).to eq(1)
       expect(counts[0].period).to eq((Date.today - 1).to_s)
@@ -69,7 +67,6 @@ RSpec.describe CountClassifications do
     it 'returns counts of events with given workflow' do
       workflow_id = diff_workflow_event.workflow_id
       params[:workflow_id] = workflow_id.to_s
-      counts = count_classifications.call(params)
       expect(counts.length).to eq(1)
       expect(counts[0].count).to eq(1)
     end
@@ -77,7 +74,6 @@ RSpec.describe CountClassifications do
     it 'returns counts of events with given project' do
       project_id = diff_project_event.project_id
       params[:project_id] = project_id.to_s
-      counts = count_classifications.call(params)
       expect(counts.length).to eq(1)
       expect(counts[0].count).to eq(1)
     end
@@ -87,7 +83,6 @@ RSpec.describe CountClassifications do
       yesterday = Date.today - 1
       params[:start_date] = last_week.to_s
       params[:end_date] = yesterday.to_s
-      counts = count_classifications.call(params)
       expect(counts.length).to eq(1)
       expect(counts[0].count).to eq(1)
     end
@@ -98,7 +93,6 @@ RSpec.describe CountClassifications do
           yesterday = Date.today - 1
           params[:workflow_id] = diff_time_event.workflow_id.to_s
           params[:end_date] = yesterday.to_s
-          counts = count_classifications.call(params)
           expect(counts.model).to be(ClassificationCounts::DailyWorkflowClassificationCount)
           expect(counts.length).to eq(1)
           expect(counts[0].count).to eq(1)
@@ -106,23 +100,49 @@ RSpec.describe CountClassifications do
       end
 
       context 'when params[:end_date] includes current date' do
-        context 'when no classification count up to previous day' do
-          context 'when no classifications for current day' do
+        before do
+          params[:end_date] = Date.today.to_s
+        end
+
+        context 'when 0 classifications up to previous day' do
+          context 'when 0 classifications for current day' do
             it 'returns from DailyWorkflowClassificationCount' do
               # Select a workflow id that has no classification
               params[:workflow_id] = '100'
-              params[:end_date] = Date.today.to_s
-              counts = count_classifications.call(params)
               expect(counts.model).to be(ClassificationCounts::DailyWorkflowClassificationCount)
               expect(counts.length).to eq(0)
             end
           end
 
           context 'when there are classifications for current day' do
-            it 'returns from HourlyWorkflowCount' do
+            before do
+              params[:workflow_id] = diff_workflow_event.workflow_id.to_s
             end
 
-            it 'returns proper start of period' do
+            it "returns today's classifications from HourlyWorkflowClassificationCount" do
+              expect(counts.model).to be(ClassificationCounts::HourlyWorkflowClassificationCount)
+              expect(counts.length).to eq(1)
+              expect(counts[0].count).to eq(1)
+            end
+
+            it 'returns current date when period is day' do
+              params[:period] = 'day'
+              expect(counts[0].period).to eq(Date.today.to_time.utc)
+            end
+
+            it 'returns start of week when period is week' do
+              params[:period] = 'week'
+              expect(counts[0].period).to eq(Date.today.at_beginning_of_week.to_time.utc)
+            end
+
+            it 'returns start of month when period is month' do
+              params[:period] = 'month'
+              expect(counts[0].period).to eq(Date.today.at_beginning_of_month.to_time.utc)
+            end
+
+            it 'returns start of year when period is year' do
+              params[:period] = 'year'
+              expect(counts[0].period).to eq(Date.today.at_beginning_of_year.to_time.utc)
             end
           end
         end


### PR DESCRIPTION
Because of how the FE calls out /classifications?workflow_id endpoint when querying from project's stats (i.e. all at once), which is hammering the API and Timescale db. 🔨

This ^ (and our non-usage of compression or data retention policies) plus our usage of Real Time Aggregates on the continuous aggregate we query workflow data from, causes querying to be not performant. (As evident when turning off Real Time Aggregation, we see faster query times and lower cpu utilization).

Because we are limited in resources and we still want Real Time Aggregation to be possible, we do the following for querying workflow classification counts ONLY:

- Create a New HourlyClassificationCountByWorkflow RealTime Aggregate
- Set a data retention policy for this new hourly workflow classification count aggregate (this should limit the amount of data the query planner will have to sift through when dealing with real time aggregates)
- Turn off real time aggregation for the DailyClassificationCount
- When querying workflow classification counts that include current date's counts, we query current date's counts via the  HourlyClassificationCountByWorkflow continuous aggregate and we query the materialized DailyClassificationCountsByWorkflow for everything before that date

Some details:
- to avoid double counting when querying workflow counts that include a query to real time aggregate, we scope querying our materialized continuous aggregate for everything up to the day before the current date (double counting can happen when materialized view gets refreshed to include current date's counts..can happen via manual refresh or cagg watermark looking too far ahead [sometimes can happen, but very rare and not a fault on our end])
- timezones are not too much of an issue here, since our Rails app is in UTC and our db time is in UTC
- mentioned in BE/Ops call (on 9/26/24) about the complexity, but this detail seemed to confuse Cliff and Zach, when current date is the start of a new bucket period (period options being `day, week, month, or year`, we need to ensure we append the current date counts as a new entry with the proper start date of the appended period. Otherwise, its a simple add current date counts to the newest bucket, if there is a newest bucket entry.  More detail in the next bullet
- In `include_today_to_scoped` in count_classifications, we take care of the following cases:
          -  for a given workflow, there are no classifications past or current => returns the empty past classifications counts
          - for a given workflow, there are past classifications but no current classifications => returns past classifications counts
          - for a given workflow, there are no past classifications but there are current classifications (i.e. a new workflow) => returns todays_classifications with proper period bucket start date
          -   for a given workflow, there are past classifications and current classifications
                    A)  if part of the most recent past classifications bucket, then add
                    B) if not, then append with proper period bucket start date
          