### PR TITLE
Update python dependency location

### DIFF
--- a/.github/workflows/deploy_lambda_production.yml
+++ b/.github/workflows/deploy_lambda_production.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          mkdir ./package && pip install --target ./package requests
+          mkdir ./python && pip install --target ./python requests
 
       - name: Zip package
         run: |

--- a/.github/workflows/deploy_lambda_staging.yml
+++ b/.github/workflows/deploy_lambda_staging.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          mkdir ./package && pip install --target ./package requests
+          mkdir ./python && pip install --target ./python requests
 
       - name: Zip package
         run: |


### PR DESCRIPTION
Change lambda forwarders' python dependency locations from `/packages` to `/python` to fix issue with python versions > 3.8.