### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,5 +1,8 @@
 name: Run Rspec
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/zooniverse/eras/security/code-scanning/11](https://github.com/zooniverse/eras/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since this workflow is a basic CI pipeline for running tests, it only requires read access to the repository contents. We will set `contents: read` as the minimal required permission. This ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
