### PR TITLE
update ruby 3.2 debian release version from buster (archived) to stable bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2-buster
+FROM ruby:3.2-bookworm
 WORKDIR /app
 ARG RAILS_ENV
 


### PR DESCRIPTION
update ruby 3.2 debian release version from buster (archived) to stable bookworm