### PR TITLE
Create updated materialized views to include project session time

### DIFF
--- a/db/migrate/20260416032005_create_daily_classification_count_and_session_time_per_project.rb
+++ b/db/migrate/20260416032005_create_daily_classification_count_and_session_time_per_project.rb
@@ -1,0 +1,27 @@
+class CreateDailyClassificationCountAndSessionTimePerProject < ActiveRecord::Migration[7.0]
+  # Meant to replace daily_classification_count_per_project.
+  # original continuous aggregate (daily_classification_count_per_project) only accounted for sum of classification count per day.
+  # there was an ask to keep track of project session time per day (i.e.  the total sesion time of all classifications of a project per day) as well.
+  disable_ddl_transaction!
+  def up
+    execute <<~SQL
+      create materialized view daily_classification_count_and_time_per_project
+      with (
+        timescaledb.continuous
+      ) as
+      select
+        time_bucket('1d', event_time) as day,
+        project_id,
+        count(*) as classification_count,
+        sum(session_time) as total_session_time
+      from classification_events
+      group by day, project_id;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      DROP materialized view daily_classification_count_and_time_per_project;
+    SQL
+  end
+end

--- a/db/migrate/20260416032005_create_daily_classification_count_and_session_time_per_project.rb
+++ b/db/migrate/20260416032005_create_daily_classification_count_and_session_time_per_project.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateDailyClassificationCountAndSessionTimePerProject < ActiveRecord::Migration[7.0]
   # Meant to replace daily_classification_count_per_project.
   # original continuous aggregate (daily_classification_count_per_project) only accounted for sum of classification count per day.

--- a/db/migrate/20260416032303_create_hourly_project_classification_count_and_time.rb
+++ b/db/migrate/20260416032303_create_hourly_project_classification_count_and_time.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class CreateHourlyProjectClassificationCountAndTime < ActiveRecord::Migration[7.0]
-   # we have to disable the migration transaction because creating materialized views within it is not allowed.
+  # we have to disable the migration transaction because creating materialized views within it is not allowed.
 
   # Due to how the front end pulls project stats (and workflow stats) all in one go, we hit performance issues; especially if a project has multiple workflows.
   # We have discovered that having a non-realtime/materialized only continous aggregate for our daily project count cagg is more performant than real time.

--- a/db/migrate/20260416032303_create_hourly_project_classification_count_and_time.rb
+++ b/db/migrate/20260416032303_create_hourly_project_classification_count_and_time.rb
@@ -1,0 +1,32 @@
+class CreateHourlyProjectClassificationCountAndTime < ActiveRecord::Migration[7.0]
+   # we have to disable the migration transaction because creating materialized views within it is not allowed.
+
+  # Due to how the front end pulls project stats (and workflow stats) all in one go, we hit performance issues; especially if a project has multiple workflows.
+  # We have discovered that having a non-realtime/materialized only continous aggregate for our daily project count cagg is more performant than real time.
+  # We plan to do the following:
+  # - Update the daily_classification_count_per_project to be materialized only (i.e. non-realtime)
+  # - Create a subsequent realtime cagg that buckets hourly that we will create data retention policies for. The plan is for up to 72 hours worth of hourly project classification counts of data.
+  # - Update project query to first query the daily counts first and then query the hourly counts for just the specific date of now.
+  disable_ddl_transaction!
+  def up
+    execute <<~SQL
+      create materialized view hourly_classification_count_and_time_per_project
+      with (
+        timescaledb.continuous
+      ) as
+      select
+        time_bucket('1 hour', event_time) as hour,
+        project_id,
+        count(*) as classification_count,
+        sum(session_time) as total_session_time
+      from classification_events where event_time > now() - INTERVAL '5 days'
+      group by hour, project_id;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      DROP materialized view hourly_classification_count_and_time_per_project;
+    SQL
+  end
+end

--- a/db/migrate/20260416033132_add_refresh_policy_for_daily_project_count_and_time.rb
+++ b/db/migrate/20260416033132_add_refresh_policy_for_daily_project_count_and_time.rb
@@ -1,0 +1,14 @@
+class AddRefreshPolicyForDailyProjectCountAndTime < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def up
+    execute <<~SQL
+      SELECT add_continuous_aggregate_policy('daily_classification_count_and_time_per_project', start_offset => INTERVAL '3 days', end_offset => INTERVAL '1 hour',  schedule_interval => INTERVAL '1 hour');
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      SELECT remove_continuous_aggregate_policy('daily_classification_count_and_time_per_project');
+    SQL
+  end
+end

--- a/db/migrate/20260416033132_add_refresh_policy_for_daily_project_count_and_time.rb
+++ b/db/migrate/20260416033132_add_refresh_policy_for_daily_project_count_and_time.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRefreshPolicyForDailyProjectCountAndTime < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
   def up

--- a/db/migrate/20260416033148_add_refresh_policy_for_hourly_project_count_and_time.rb
+++ b/db/migrate/20260416033148_add_refresh_policy_for_hourly_project_count_and_time.rb
@@ -1,0 +1,14 @@
+class AddRefreshPolicyForHourlyProjectCountAndTime < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def up
+    execute <<~SQL
+      SELECT add_continuous_aggregate_policy('hourly_classification_count_and_time_per_project',start_offset => INTERVAL '5 days', end_offset => INTERVAL '30 minutes', schedule_interval => INTERVAL '1 h');
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      SELECT remove_continuous_aggregate_policy('hourly_classification_count_and_time_per_project');
+    SQL
+  end
+end

--- a/db/migrate/20260416033148_add_refresh_policy_for_hourly_project_count_and_time.rb
+++ b/db/migrate/20260416033148_add_refresh_policy_for_hourly_project_count_and_time.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRefreshPolicyForHourlyProjectCountAndTime < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
   def up

--- a/db/migrate/20260416033213_add_retention_policy_for_hourly_project_count_and_time.rb
+++ b/db/migrate/20260416033213_add_retention_policy_for_hourly_project_count_and_time.rb
@@ -1,0 +1,14 @@
+class AddRetentionPolicyForHourlyProjectCountAndTime < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def up
+    execute <<~SQL
+      SELECT add_retention_policy('hourly_classification_count_and_time_per_project', drop_after => INTERVAL '3 days');
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      SELECT remove_retention_policy('hourly_classification_count_and_time_per_project');
+    SQL
+  end
+end

--- a/db/migrate/20260416033213_add_retention_policy_for_hourly_project_count_and_time.rb
+++ b/db/migrate/20260416033213_add_retention_policy_for_hourly_project_count_and_time.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRetentionPolicyForHourlyProjectCountAndTime < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
   def up

--- a/db/migrate/20260422200936_create_hourly_classification_count.rb
+++ b/db/migrate/20260422200936_create_hourly_classification_count.rb
@@ -1,0 +1,22 @@
+class CreateHourlyClassificationCount < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def up
+    execute <<~SQL
+      create materialized view hourly_classification_count
+      with (
+        timescaledb.continuous
+      ) as
+      select
+        time_bucket('1 hour', event_time) as hour,
+        count(*) as classification_count
+      from classification_events where event_time > now() - INTERVAL '5 days'
+      group by hour;
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      DROP materialized view hourly_classification_count;
+    SQL
+  end
+end

--- a/db/migrate/20260422201034_add_refresh_policy_for_hourly_count.rb
+++ b/db/migrate/20260422201034_add_refresh_policy_for_hourly_count.rb
@@ -1,0 +1,14 @@
+class AddRefreshPolicyForHourlyCount < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def up
+    execute <<~SQL
+      SELECT add_continuous_aggregate_policy('hourly_classification_count',start_offset => INTERVAL '5 days', end_offset => INTERVAL '30 minutes', schedule_interval => INTERVAL '1 h');
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      SELECT remove_continuous_aggregate_policy('hourly_classification_count');
+    SQL
+  end
+end

--- a/db/migrate/20260422201059_add_retention_policy_for_hourly_count.rb
+++ b/db/migrate/20260422201059_add_retention_policy_for_hourly_count.rb
@@ -1,0 +1,14 @@
+class AddRetentionPolicyForHourlyCount < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+  def up
+    execute <<~SQL
+      SELECT add_retention_policy('hourly_classification_count', drop_after => INTERVAL '3 days');
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      SELECT remove_retention_policy('hourly_classification_count');
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_16_033213) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_22_201059) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "timescaledb"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_27_220919) do
+ActiveRecord::Schema[7.0].define(version: 2026_04_16_033213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "timescaledb"


### PR DESCRIPTION
Create updated materialized views to include project session time.

**Changes**
- Create DailyProjectClassificationCountAndTime to consider project's total session time in a day
- Create HourlyProjectClassificationCountAndTime to deal with follow-up PRs around optimizing Project Stats Page
- Add Proper Refresh Policies for the newly created 

DailyProjectClassificationCountAndTime is meant to replace DailyProjectClassificationCount. Original view (DailyProjectClassificationCount) only takes into account a project's classification count per day. On retrospective, we realized that there was a want to consider taking a project's total session time per day (even for non-logged in/anonymous users). 

### **In order the next steps after merge, is TODO:** 

- [ ]  replace DailyProjectClassificationCount with DailyProjectClassificationCountAndTime

- [ ] Merge, Test, and Deploy
- [ ]  then DROP DailyProjectClassificationCount continuous aggregate to free up space (24 kB)
- [ ]  remove DailyProjectClassificationCount's refresh policy
- [x]  **Then work on Project Count Stats Efficiencies** (Similar to workflow, we Alter DailyProjectCountAndTime CAgg to a Non-Real Time Aggregate)
- [x]  Update logic so that anything that any queries for "NOW()" will query from the real-time hourly aggregate appended with the appropriate non-realtime aggregate

Side note: Apparently this strategy ^ (i.e. using hourly for real time and daily as non-realtime) is now a recommended strategy by Timescale/TigerData. https://www.tigerdata.com/docs/learn/continuous-aggregates/hierarchical-continuous-aggregates. Glad to see that we were ahead of recommendations. 😏 🧠 