### PR TITLE
Replace DailyProjectClassificationCount with daily_project_classification_count_and_time

### DIFF
--- a/app/models/classification_counts/daily_project_classification_count.rb
+++ b/app/models/classification_counts/daily_project_classification_count.rb
@@ -2,8 +2,9 @@
 
 module ClassificationCounts
   class DailyProjectClassificationCount < ApplicationRecord
-    self.table_name = 'daily_classification_count_per_project'
+    self.table_name = 'daily_classification_count_and_time_per_project'
     attribute :classification_count, :integer
+    attribute :total_session_time, :integer
 
     def readonly?
       true

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -44,11 +44,12 @@ namespace :db do
     SQL
 
     ActiveRecord::Base.connection.execute <<-SQL
-      CREATE MATERIALIZED VIEW IF NOT EXISTS daily_classification_count_per_project
+      CREATE MATERIALIZED VIEW IF NOT EXISTS daily_classification_count_and_time_per_project
       WITH (timescaledb.continuous) AS
       SELECT time_bucket('1 day', event_time) AS day,
       project_id,
-            count(*) as classification_count
+        count(*) as classification_count,
+        sum(session_time) as total_session_time
       FROM classification_events
       GROUP BY day, project_id;
     SQL
@@ -200,7 +201,7 @@ namespace :db do
     ActiveRecord::Base.connection.execute <<-SQL
     DROP MATERIALIZED VIEW IF EXISTS daily_classification_counts CASCADE;
     DROP MATERIALIZED VIEW IF EXISTS daily_classification_count_per_workflow CASCADE;
-    DROP MATERIALIZED VIEW IF EXISTS daily_classification_count_per_project CASCADE;
+    DROP MATERIALIZED VIEW IF EXISTS daily_classification_count_and_time_per_project CASCADE;
     DROP MATERIALIZED VIEW IF EXISTS daily_comment_count CASCADE;
     DROP MATERIALIZED VIEW IF EXISTS daily_comment_count_per_project_and_user CASCADE;
     DROP MATERIALIZED VIEW IF EXISTS daily_comment_count_per_user CASCADE;


### PR DESCRIPTION
Follow up to https://github.com/zooniverse/eras/pull/109

On retro, we realized that getting Project Session Time is something team would like to have (currently not used, but may be used in the future for internal project review analysis.) 


Changes: 
- replace call from daily_classification_count_per_project to the new daily_classification_count_and_time_per_project
- update db rake task for specs so that new cagg can be read 


### **TODO AFTER MERGE AND DEPLOY**

- [ ] Remove refresh policy for daily_classification_count_per_project cagg (since cagg is no longer used and no longer needed)
- [ ]  Remove unused daily_classification_count_per_project cagg to free up disk space