### PR TITLE
create forward migration to create daily_classification_count_and_time with no data and materialized only

### DIFF
--- a/db/migrate/20260416032005_create_daily_classification_count_and_session_time_per_project.rb
+++ b/db/migrate/20260416032005_create_daily_classification_count_and_session_time_per_project.rb
@@ -9,7 +9,8 @@ class CreateDailyClassificationCountAndSessionTimePerProject < ActiveRecord::Mig
     execute <<~SQL
       create materialized view daily_classification_count_and_time_per_project
       with (
-        timescaledb.continuous
+        timescaledb.continuous,
+        timescaledb.materialized_only = true
       ) as
       select
         time_bucket('1d', event_time) as day,

--- a/db/migrate/20260505182319_ensure_daily_classification_cagg_created_with_no_data.rb
+++ b/db/migrate/20260505182319_ensure_daily_classification_cagg_created_with_no_data.rb
@@ -1,0 +1,32 @@
+class EnsureDailyClassificationCaggCreatedWithNoData < ActiveRecord::Migration[7.0]
+  # Create continuous aggregate if it does not exist with no data to get production in sync with staging
+  # without cagg backfilling in one go. We must backfill gradually in production due to disk space limitations and CPU usage limitations.
+  def change
+    execute <<~SQL
+      DO $$
+      BEGIN
+        -- Only create if it doesn't already exist
+        IF NOT EXISTS (
+          SELECT 1
+          FROM timescaledb_information.continuous_aggregates
+          WHERE view_name = 'daily_classification_count_and_time_per_project'
+        ) THEN
+
+          CREATE MATERIALIZED VIEW daily_classification_count_and_time_per_project
+          WITH (timescaledb.continuous,
+            timescaledb.materialized_only = true
+          ) AS
+          SELECT
+            time_bucket('1d', event_time) AS day,
+            project_id,
+            count(*) AS classification_count,
+            sum(session_time) AS total_session_time
+          FROM classification_events
+          GROUP BY day, project_id
+          WITH NO DATA;
+
+        END IF;
+      END $$;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2026_04_22_201059) do
+ActiveRecord::Schema[7.0].define(version: 2026_05_05_182319) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "timescaledb"


### PR DESCRIPTION
After the failure of https://github.com/zooniverse/eras/pull/109 in production (due to cagg backfilling all data of all time as soon as create which spikes CPU usage and spikes disk usage. [Can fix by creating cagg  with 'WITH NO DATA' and making cagg materialized only vs real time]). Prod db is no longer in sync with Staging.

In order to move forward in prod, we had to fake migrations that creates the cagg without WITH NO DATA and add a fixer forward migration that creates the cagg with no data and materialized only if it does not exist. Then in prod we manually backfill cagg. 